### PR TITLE
Fix name of default branch in publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: docs
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       - "*"
 
@@ -16,10 +16,10 @@ jobs:
       - name: checks for the label
         id: label_step
         run: |
-          if [[ "${{ github.ref  }}" == "refs/heads/master" ]]; then
+          if [[ "${{ github.ref  }}" == "refs/heads/main" ]]; then
                 echo "version=latest" >> $GITHUB_OUTPUT
           fi
-          if [[ "${{ github.ref_type }}" == "branch" ]] && [[ "${{ github.ref  }}" != "refs/heads/master" ]]; then
+          if [[ "${{ github.ref_type }}" == "branch" ]] && [[ "${{ github.ref  }}" != "refs/heads/main" ]]; then
                 exit 1
           fi
           if [[ "${{ github.ref_type }}" == "tag" ]]; then


### PR DESCRIPTION
Sorry, I should have checked more carefully the workflow before merging #35 