### PR TITLE
Updating README file on installation for new qibotn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Currently, the supported tensor network libraries are:
 To get started:
 
 ```sh
-pip install .
+git clone https://github.com/qiboteam/qibotn.git
+cd qibotn
+poetry install
 ```
 
 to install the tools and dependencies. A few extras are provided, check `pyproject.toml` in

--- a/README.md
+++ b/README.md
@@ -27,22 +27,22 @@ Currently, the supported tensor network libraries are:
 - [quimb](https://quimb.readthedocs.io/en/latest/), an easy but fast python library for ‘quantum information many-body’ calculations, focusing primarily on tensor networks.
 
 ## Installation
- 
+
 To get started:
- 
+
 ```sh
 pip install qibotn
 ```
- 
+
 to install the tools and dependencies. A few extras are provided, check `pyproject.toml` in
 case you need them.
- 
+
 <!-- TODO: describe extras, after Poetry adoption and its groups -->
- 
+
 ## Contribute
- 
+
 To contribute, please install using poetry:
- 
+
 ```sh
 git clone https://github.com/qiboteam/qibotn.git
 cd qibotn

--- a/README.md
+++ b/README.md
@@ -27,19 +27,27 @@ Currently, the supported tensor network libraries are:
 - [quimb](https://quimb.readthedocs.io/en/latest/), an easy but fast python library for ‘quantum information many-body’ calculations, focusing primarily on tensor networks.
 
 ## Installation
-
+ 
 To get started:
-
+ 
+```sh
+pip install qibotn
+```
+ 
+to install the tools and dependencies. A few extras are provided, check `pyproject.toml` in
+case you need them.
+ 
+<!-- TODO: describe extras, after Poetry adoption and its groups -->
+ 
+## Contribute
+ 
+To contribute, please install using poetry:
+ 
 ```sh
 git clone https://github.com/qiboteam/qibotn.git
 cd qibotn
 poetry install
 ```
-
-to install the tools and dependencies. A few extras are provided, check `pyproject.toml` in
-case you need them.
-
-<!-- TODO: describe extras, after Poetry adoption and its groups -->
 
 ## Sample Codes
 


### PR DESCRIPTION
To help new users of qibotn to install qibotn in the right manner since qibotn no longer uses `pip install .` for installation after the release. Changing the directions for installation in the readme file to the following

```
git clone https://github.com/qiboteam/qibotn.git
cd qibotn
poetry install
```