### PR TITLE
refactor: use direct TN contraction for symbolic expectation values

### DIFF
--- a/src/qibotn/backends/quimb.py
+++ b/src/qibotn/backends/quimb.py
@@ -241,22 +241,22 @@ def exp_value_observable_symbolic(
                 "within a single term (e.g. (0,0,0) is invalid).",
             )
 
-    ket = self._qibo_circuit_to_quimb(
+    circuit_tn = self._qibo_circuit_to_quimb(
         circuit,
         quimb_circuit_type=self.circuit_ansatz,
         gate_opts={"max_bond": self.max_bond_dimension, "cutoff": self.svd_cutoff},
     ).psi
-
-    bra = ket.copy().H
+    bra = circuit_tn.copy().H
 
     expectation_value = 0.0
     for opstr, sites, coeff in zip(operators_list, sites_list, coeffs_list):
+        ket = circuit_tn.copy()
         coeff = coeff.real
         for label, site in zip(opstr, sites): 
             op_matrix = qu.pauli(label.upper())
             ket.gate_(op_matrix, site)
-        exp_values = (bra & ket).contract(optimize="auto-hq").real
-        expectation_value = expectation_value + coeff * exp_values
+        exp_value = (bra & ket).contract(optimize="auto-hq").real
+        expectation_value = expectation_value + coeff * exp_value
 
     return expectation_value
 

--- a/src/qibotn/backends/quimb.py
+++ b/src/qibotn/backends/quimb.py
@@ -252,7 +252,7 @@ def exp_value_observable_symbolic(
     expectation_value = 0.0
     for opstr, sites, coeff in zip(operators_list, sites_list, coeffs_list):
         coeff = coeff.real
-        for label, site in zip(opstr, sites): 
+        for label, site in zip(opstr, sites):
             op_matrix = qu.pauli(label.upper())
             ket.gate_(op_matrix, site)
         exp_values = (bra & ket).contract(optimize="auto-hq").real
@@ -309,7 +309,6 @@ def _qibo_circuit_to_quimb(
                 *qubits,
             )
     return circ
-
 
 
 CLASSES_ROOTS = {"numpy": "Numpy", "torch": "PyTorch", "jax": "Jax"}

--- a/src/qibotn/backends/quimb.py
+++ b/src/qibotn/backends/quimb.py
@@ -252,7 +252,7 @@ def exp_value_observable_symbolic(
     for opstr, sites, coeff in zip(operators_list, sites_list, coeffs_list):
         ket = circuit_tn.copy()
         coeff = coeff.real
-        for label, site in zip(opstr, sites): 
+        for label, site in zip(opstr, sites):
             op_matrix = qu.pauli(label.upper())
             ket.gate_(op_matrix, site)
         exp_value = (bra & ket).contract(optimize="auto-hq").real
@@ -309,7 +309,6 @@ def _qibo_circuit_to_quimb(
                 *qubits,
             )
     return circ
-
 
 
 CLASSES_ROOTS = {"numpy": "Numpy", "torch": "PyTorch", "jax": "Jax"}

--- a/src/qibotn/backends/quimb.py
+++ b/src/qibotn/backends/quimb.py
@@ -255,7 +255,7 @@ def exp_value_observable_symbolic(
         for label, site in zip(opstr, sites):
             op_matrix = qu.pauli(label.upper())
             ket.gate_(op_matrix, site)
-        exp_value = (bra & ket).contract(optimize="auto-hq").real
+        exp_value = (bra & ket).contract(optimize=self.contraction_optimizer).real
         expectation_value = expectation_value + coeff * exp_value
 
     return expectation_value


### PR DESCRIPTION
Replace the use of `local_expectation` with a manual gate-application and contraction logic in `exp_value_observable_symbolic`.

The previous implementation using `local_expectation` required the  construction of dense observables. For larger-scale Hamiltonians,  dense matrix construction scales badly leading to memory exhaustion and system crashes (which happened to me).

Changes:
- Implemented a "gate-by-gate" application of Pauli operators directly o a copy of the state tensor network using `.gate_()`.
- Computed the expectation value via the inner product